### PR TITLE
ARIES-1519 - NPE when DistributionProvider has no

### DIFF
--- a/rsa/src/main/java/org/apache/aries/rsa/core/DistributionProviderTracker.java
+++ b/rsa/src/main/java/org/apache/aries/rsa/core/DistributionProviderTracker.java
@@ -28,6 +28,7 @@ import org.osgi.framework.BundleException;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.remoteserviceadmin.RemoteConstants;
 import org.osgi.service.remoteserviceadmin.RemoteServiceAdmin;
 import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
@@ -51,8 +52,13 @@ public class DistributionProviderTracker extends ServiceTracker<DistributionProv
                                                                     provider);
         RemoteServiceadminFactory rsaf = new RemoteServiceadminFactory(rsaCore);
         Dictionary<String, Object> props = new Hashtable<String, Object>();
-        props.put("remote.intents.supported", reference.getProperty("remote.intents.supported"));
-        props.put("remote.configs.supported", reference.getProperty("remote.configs.supported"));
+        Object value = reference.getProperty(RemoteConstants.REMOTE_INTENTS_SUPPORTED);
+        value = value == null ? "" : value;
+        props.put(RemoteConstants.REMOTE_INTENTS_SUPPORTED, value);
+
+        value = reference.getProperty(RemoteConstants.REMOTE_CONFIGS_SUPPORTED);
+        value = value == null ? "" : value;
+        props.put(RemoteConstants.REMOTE_CONFIGS_SUPPORTED, value);
         LOG.info("Registering RemoteServiceAdmin for provider " + provider.getClass().getName());
         return context.registerService(RemoteServiceAdmin.class.getName(), rsaf, props);
     }

--- a/rsa/src/test/java/org/apache/aries/rsa/core/DistributionProviderTrackerTest.java
+++ b/rsa/src/test/java/org/apache/aries/rsa/core/DistributionProviderTrackerTest.java
@@ -79,4 +79,37 @@ public class DistributionProviderTrackerTest {
         tracker.removedService(providerRef, rsaReg);
         c.verify();
     }
+
+    @Test
+    public void testAddingWithNullValues() throws InvalidSyntaxException {
+        IMocksControl c = EasyMock.createControl();
+        DistributionProvider provider = c.createMock(DistributionProvider.class);
+
+        ServiceReference<DistributionProvider> providerRef = c.createMock(ServiceReference.class);
+        EasyMock.expect(providerRef.getProperty(RemoteConstants.REMOTE_INTENTS_SUPPORTED)).andReturn(null);
+        EasyMock.expect(providerRef.getProperty(RemoteConstants.REMOTE_CONFIGS_SUPPORTED)).andReturn(null);
+
+        BundleContext context = c.createMock(BundleContext.class);
+        String filterSt = String.format("(objectClass=%s)", DistributionProvider.class.getName());
+        Filter filter = FrameworkUtil.createFilter(filterSt);
+        EasyMock.expect(context.createFilter(filterSt)).andReturn(filter);
+        EasyMock.expect(context.getService(providerRef)).andReturn(provider);
+        ServiceRegistration rsaReg = c.createMock(ServiceRegistration.class);
+        EasyMock.expect(context.registerService(EasyMock.isA(String.class), EasyMock.isA(ServiceFactory.class),
+                                                EasyMock.isA(Dictionary.class)))
+            .andReturn(rsaReg).atLeastOnce();
+
+        context.addServiceListener(EasyMock.isA(ServiceListener.class), EasyMock.isA(String.class));
+        EasyMock.expectLastCall();
+
+        final BundleContext apiContext = c.createMock(BundleContext.class);
+        c.replay();
+        DistributionProviderTracker tracker = new DistributionProviderTracker(context) {
+            protected BundleContext getAPIContext() {
+                return apiContext;
+            };
+        };
+        tracker.addingService(providerRef);
+        c.verify();
+    }
 }


### PR DESCRIPTION
remote.intents.supported

adds a null check and defaults to an empty string if either
remote.intents.supported or remote.configs.supported is not set by a
distribution provider
