### PR TITLE
Fix for inner class not matching pattern 

### DIFF
--- a/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/importer/FilterHelper.java
+++ b/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/importer/FilterHelper.java
@@ -20,11 +20,10 @@ package org.apache.aries.rsa.topologymanager.importer;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.osgi.framework.Constants;
 
 public final class FilterHelper {
-    private static final String OBJECTCLASS_EXPRESSION = ".*\\(" + Constants.OBJECTCLASS + "=([a-zA-Z_0-9.]+)\\).*";
+    private static final String OBJECTCLASS_EXPRESSION = ".*\\(" + Constants.OBJECTCLASS + "=([^)]+)\\).*";
     private static final Pattern OBJECTCLASS_PATTERN = Pattern.compile(OBJECTCLASS_EXPRESSION);
 
     private FilterHelper() {


### PR DESCRIPTION
Fix for inner class not matching pattern
(e.g. "objectClass=com.stackleader.training.grpc.helloworld.api.GreeterGrpc$Greeter)")
