### PR TITLE
Fixes Zookeeper's path when names start with a Dot

### DIFF
--- a/discovery/zookeeper/src/main/java/org/apache/aries/rsa/discovery/zookeeper/util/Utils.java
+++ b/discovery/zookeeper/src/main/java/org/apache/aries/rsa/discovery/zookeeper/util/Utils.java
@@ -30,6 +30,10 @@ public final class Utils {
     }
 
     public static String getZooKeeperPath(String name) {
+        if (name != null && name.startsWith(".")) {
+            name = name.substring(1);
+        }
+
         return name == null || name.isEmpty() ? PATH_PREFIX : PATH_PREFIX + '/' + name.replace('.', '/');
     }
 

--- a/discovery/zookeeper/src/test/java/org/apache/aries/rsa/discovery/zookeeper/util/UtilsTest.java
+++ b/discovery/zookeeper/src/test/java/org/apache/aries/rsa/discovery/zookeeper/util/UtilsTest.java
@@ -28,6 +28,9 @@ public class UtilsTest extends TestCase {
         assertEquals(Utils.PATH_PREFIX + '/' + "org/example/Test",
             Utils.getZooKeeperPath("org.example.Test"));
 
+        assertEquals(Utils.PATH_PREFIX + '/' + "camelBlueprint/componentResolver/properties",
+                Utils.getZooKeeperPath(".camelBlueprint.componentResolver.properties"));
+
         // used for the recursive discovery
         assertEquals(Utils.PATH_PREFIX, Utils.getZooKeeperPath(null));
         assertEquals(Utils.PATH_PREFIX, Utils.getZooKeeperPath(""));


### PR DESCRIPTION
When using camel-blueprint with aries.rsa.discovery.zookeeper some properties start with a dot, for example ".camelBlueprint.componentResolver.properties"
at the time of trying to create a path for ZooKeeper, an error is generated:

```
2017-09-03T17: 20: 26,481 | ERROR | features-1-thread-1 | Felix | - - | Bundle org.apache.aries.rsa.discovery.zookeeper [141] EventDispatcher: Error during dispatch. (java.lang.IllegalArgumentException: Invalid path string "/osgi/service_registry//camelBlueprint/componentResolver/properties" caused by empty node name specified @ 23)
at org.apache.zookeeper.common.PathUtils.validatePath (PathUtils.java:99) ~ [?:?]
```