### PR TITLE
Synchronization fix for TopologyManager to prevent ConcurrentModificationException

### DIFF
--- a/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/importer/MultiMap.java
+++ b/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/importer/MultiMap.java
@@ -38,7 +38,7 @@ public class MultiMap<T> {
     public synchronized void put(String key, T value) {
         Set<T> values = map.get(key);
         if (values == null) {
-            values = new HashSet<>();
+            values = Collections.synchronizedSet(new HashSet<T>());
             map.put(key, values);
         }
         values.add(value);
@@ -67,7 +67,7 @@ public class MultiMap<T> {
         }
     }
 
-    public void clear() {
+    public synchronized void clear() {
         map.clear();
     }
 }


### PR DESCRIPTION
When running multiple endpoints, a part of the dependency causes the endpoints to be closed and restarted - in this case, sometimes this error occurred.

`java.util.ConcurrentModificationException
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1437) [?:?]
	at java.util.HashMap$KeyIterator.next(HashMap.java:1461) [?:?]
	at org.apache.aries.rsa.topologymanager.importer.TopologyManagerImport.unImportForGoneEndpoints(TopologyManagerImport.java:183) [82:org.apache.aries.rsa.topology-manager:1.12.0]
	at org.apache.aries.rsa.topologymanager.importer.TopologyManagerImport.syncronizeImports(TopologyManagerImport.java:127) [82:org.apache.aries.rsa.topology-manager:1.12.0]
	at org.apache.aries.rsa.topologymanager.importer.TopologyManagerImport.access$000(TopologyManagerImport.java:47) [82:org.apache.aries.rsa.topology-manager:1.12.0]
	at org.apache.aries.rsa.topologymanager.importer.TopologyManagerImport$1.run(TopologyManagerImport.java:119) [82:org.apache.aries.rsa.topology-manager:1.12.0]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:?]
	at java.lang.Thread.run(Thread.java:748) [?:?]`