### PR TITLE
Add explicit IllegalStateException in exportService

### DIFF
--- a/rsa/src/main/java/org/apache/aries/rsa/core/RemoteServiceAdminCore.java
+++ b/rsa/src/main/java/org/apache/aries/rsa/core/RemoteServiceAdminCore.java
@@ -225,6 +225,9 @@ public class RemoteServiceAdminCore implements RemoteServiceAdmin {
             }
             final BundleContext serviceContext = serviceBundle.getBundleContext();
             final Object serviceO = serviceContext.getService(serviceReference);
+            if (serviceO == null) {
+                throw new IllegalStateException("service object is null (service was unregistered?)");
+            }
             final Class<?>[] interfaces = getInterfaces(serviceO, interfaceNames);
             final Map<String, Object> eprops = createEndpointProps(serviceProperties, interfaces);
             


### PR DESCRIPTION
when service object is null, this makes it clearer what's going on than getting an arbitrary NPE somewhere down the line.