### PR TITLE
Two inconsistency introduced with ARIES-1941

### DIFF
--- a/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/importer/MultiMap.java
+++ b/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/importer/MultiMap.java
@@ -65,12 +65,14 @@ public class MultiMap<T> {
     }
 
     public synchronized void remove(T toRemove) {
-        for (String key : map.keySet()) {
+        // Use copy of keySet, as subsequent remove may modify the keySet itself
+        Set<String> keys = new HashSet<>(map.keySet());
+        for (String key : keys) {
             remove(key, toRemove);
         }
     }
 
-    public void clear() {
+    public synchronized void clear() {
         map.clear();
     }
 }


### PR DESCRIPTION
1) The copy of the keySet was incorrectly removed by f14ba9d, and is needed regardless of the external methods being thread-safe.
2) Clear method of MultiMap must use the same mutex as the other public methods.