### PR TITLE
Multimap improvements

### DIFF
--- a/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/importer/MultiMap.java
+++ b/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/importer/MultiMap.java
@@ -27,17 +27,18 @@ import java.util.concurrent.CopyOnWriteArraySet;
 /**
  * Minimal implementation of a thread-safe map where each key can have multiple values.
  *
- * @param <T> the value type
+ * @param <K> the key type
+ * @param <V> the value type
  */
-public class MultiMap<T> {
+public class MultiMap<K, V> {
 
-    private Map<String, Set<T>> map;
+    private Map<K, Set<V>> map;
     
     public MultiMap() {
         map = new ConcurrentHashMap<>();
     }
     
-    public void put(String key, T value) {
+    public void put(K key, V value) {
         map.compute(key, (k, v) -> {
             if (v == null) {
                 v = new CopyOnWriteArraySet<>();
@@ -47,23 +48,23 @@ public class MultiMap<T> {
         });
     }
 
-    public Set<T> get(String key) {
-        Set<T> values = map.get(key);
+    public Set<V> get(K key) {
+        Set<V> values = map.get(key);
         return values == null ? Collections.emptySet() : Collections.unmodifiableSet(values);
     }
 
-    public void remove(String key, T value) {
+    public void remove(K key, V value) {
         // reminder: returning null from the compute lambda will remove the mapping
         map.compute(key, (k, v) -> v != null && v.remove(value) && v.isEmpty() ? null : v);
     }
 
-    public void remove(T value) {
-        for (String key : map.keySet()) {
+    public void remove(V value) {
+        for (K key : map.keySet()) {
             remove(key, value);
         }
     }
 
-    public Set<String> keySet() {
+    public Set<K> keySet() {
         return map.keySet();
     }
 

--- a/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/importer/TopologyManagerImport.java
+++ b/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/importer/TopologyManagerImport.java
@@ -56,12 +56,12 @@ public class TopologyManagerImport implements EndpointEventListener, RemoteServi
     /**
      * List of Endpoints by matched filter that were reported by the EndpointListener and can be imported
      */
-    private final MultiMap<EndpointDescription> importPossibilities = new MultiMap<>();
+    private final MultiMap<String, EndpointDescription> importPossibilities = new MultiMap<>();
 
     /**
      * List of already imported Endpoints by their matched filter
      */
-    private final MultiMap<ImportRegistration> importedServices = new MultiMap<>();
+    private final MultiMap<String, ImportRegistration> importedServices = new MultiMap<>();
     
     public TopologyManagerImport(BundleContext bc) {
         this.rsaSet = new HashSet<>();

--- a/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/importer/TopologyManagerImport.java
+++ b/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/importer/TopologyManagerImport.java
@@ -188,7 +188,7 @@ public class TopologyManagerImport implements EndpointEventListener, RemoteServi
 
     private void unImport(ImportReference ref) {
         List<ImportRegistration> removed = new ArrayList<>();
-        HashSet<String> imported = new HashSet<>(importedServices.keySet());
+        Set<String> imported = importedServices.keySet();
         for (String key : imported) {
             for (ImportRegistration ir : importedServices.get(key)) {
                 if (ir.getImportReference().equals(ref)) {


### PR DESCRIPTION
Following the recent concurrency fixes in ARIES-1941, here is a further simplification and improvement in concurrency.

ConcurrentHashMap and CopyOnWriteArraySet are used to avoid all the iterator issues and unnecessary defensive copying (they are both iteration+modification safe), compute is used for atomically adding/removing the inner sets, and the rest is done with the efficient built-in concurrency without the need for additional external synchronization. The one potential addition would be to return an unmodifiable set in the get method, but since it's used only in one class and only for iteration, I left it as just a comment. Unmodifiable is also ok though if you prefer.

Would love to have it reviewed before I push it to make sure I didn't miss anything... concurrency can be tricky :-)

Any input from @cschneider @glimmerveen or anyone else would be appreciated.