### PR TITLE
fix ConcurrentModificationException in ServiceExportsRepository

### DIFF
--- a/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/exporter/ServiceExportsRepository.java
+++ b/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/exporter/ServiceExportsRepository.java
@@ -139,7 +139,8 @@ public class ServiceExportsRepository implements Closeable {
     public List<EndpointDescription> getAllEndpoints() {
         List<EndpointDescription> endpoints = new ArrayList<>();
 
-        for (Collection<ExportRegistrationHolder> exports : exportsMap.values()) {
+        final ArrayList<Collection<ExportRegistrationHolder>> values = new ArrayList(exportsMap.values());
+        for (Collection<ExportRegistrationHolder> exports : values) {
             for (ExportRegistrationHolder reg : exports) {
                 ExportReference exportRef = reg.getRegistration().getExportReference();
                 if (exportRef != null) {

--- a/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/exporter/ServiceExportsRepository.java
+++ b/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/exporter/ServiceExportsRepository.java
@@ -67,14 +67,14 @@ public class ServiceExportsRepository implements Closeable {
             return registration;
         }
 
-        void close() {
+        synchronized void close() {
             if (reference != null) {
                 notifier.sendEvent(new EndpointEvent(EndpointEvent.REMOVED, endpoint));
                 registration.close();
             }
         }
 
-        public void update(ServiceReference<?> sref) {
+        synchronized public void update(ServiceReference<?> sref) {
             EndpointDescription updatedEndpoint = registration.update(getServiceProps(sref));
             if (reference != null) {
                 this.endpoint = updatedEndpoint;
@@ -97,7 +97,7 @@ public class ServiceExportsRepository implements Closeable {
         this.notifier = notifier;
     }
 
-    public void close() {
+    public synchronized void close() {
         LOG.debug("Closing registry for RemoteServiceAdmin {}", rsa.getClass().getName());
         for (ServiceReference<?> sref : exportsMap.keySet()) {
             removeService(sref);
@@ -136,11 +136,10 @@ public class ServiceExportsRepository implements Closeable {
         }
     }
 
-    public List<EndpointDescription> getAllEndpoints() {
+    public synchronized List<EndpointDescription> getAllEndpoints() {
         List<EndpointDescription> endpoints = new ArrayList<>();
 
-        final ArrayList<Collection<ExportRegistrationHolder>> values = new ArrayList(exportsMap.values());
-        for (Collection<ExportRegistrationHolder> exports : values) {
+        for (Collection<ExportRegistrationHolder> exports : exportsMap.values()) {
             for (ExportRegistrationHolder reg : exports) {
                 ExportReference exportRef = reg.getRegistration().getExportReference();
                 if (exportRef != null) {

--- a/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/exporter/ServiceExportsRepository.java
+++ b/topology-manager/src/main/java/org/apache/aries/rsa/topologymanager/exporter/ServiceExportsRepository.java
@@ -138,8 +138,8 @@ public class ServiceExportsRepository implements Closeable {
 
     public List<EndpointDescription> getAllEndpoints() {
         List<EndpointDescription> endpoints = new ArrayList<>();
-        for (ServiceReference<?> sref : exportsMap.keySet()) {
-            Collection<ExportRegistrationHolder> exports = exportsMap.get(sref);
+
+        for (Collection<ExportRegistrationHolder> exports : exportsMap.values()) {
             for (ExportRegistrationHolder reg : exports) {
                 ExportReference exportRef = reg.getRegistration().getExportReference();
                 if (exportRef != null) {


### PR DESCRIPTION
When using Aries RSA we regularly experience a ConcurrentModificationException in ServiceExportsRepository. This PR contains a very simple and straightforward fix for that.