### PR TITLE
ARIES-2113 - Distinguish result object, invoked method exceptions and…

### DIFF
--- a/provider/tcp/src/main/java/org/apache/aries/rsa/provider/tcp/MethodInvoker.java
+++ b/provider/tcp/src/main/java/org/apache/aries/rsa/provider/tcp/MethodInvoker.java
@@ -42,14 +42,10 @@ public class MethodInvoker {
         this.primTypes.put(Character.TYPE, Character.class);
     }
 
-    public Object invoke(String methodName, Object[] args) {
+    public Object invoke(String methodName, Object[] args) throws Exception {
         Class<?>[] parameterTypesAr = getTypes(args);
-        try {
-            Method method = getMethod(methodName, parameterTypesAr);
-            return method.invoke(service, args);
-        } catch (Throwable e) {
-            return e;
-        }
+        Method method = getMethod(methodName, parameterTypesAr);
+        return method.invoke(service, args);
     }
 
     private Method getMethod(String methodName, Class<?>[] parameterTypesAr) {

--- a/provider/tcp/src/test/java/org/apache/aries/rsa/provider/tcp/MethodInvokerTest.java
+++ b/provider/tcp/src/test/java/org/apache/aries/rsa/provider/tcp/MethodInvokerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.aries.rsa.provider.tcp;
+
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+
+import static org.junit.Assert.*;
+
+public class MethodInvokerTest {
+
+    @Test
+    public void testExceptionThrown() {
+        class Tester {
+            public String throwSomething() { throw new UnsupportedOperationException(); }
+        }
+
+        Tester tester = new Tester();
+        MethodInvoker invoker = new MethodInvoker(tester);
+        assertThrows(InvocationTargetException.class, () -> invoker.invoke("throwSomething", null));
+        assertThrows(UnsupportedOperationException.class, () -> {
+            try {
+                invoker.invoke("throwSomething", null);
+            } catch (InvocationTargetException ite) {
+                throw ite.getCause();
+            }
+        });
+    }
+
+    @Test
+    public void testExceptionReturned() throws Exception {
+        class Tester {
+            public Object returnSomething() { return new UnsupportedOperationException(); }
+        }
+
+        Tester tester = new Tester();
+        MethodInvoker invoker = new MethodInvoker(tester);
+        assertEquals(UnsupportedOperationException.class, invoker.invoke("returnSomething", null).getClass());
+    }
+
+}


### PR DESCRIPTION
… provider exceptions

The test uses assertThrows which requires the junit upgrade from ARIES-2117 (https://github.com/apache/aries-rsa/pull/47), but I'm opening this PR anyway for review, will rebase when junit is upgraded.