### PR TITLE
Aries-2121 Add TCP provider connection persistence with connection pool

### DIFF
--- a/itests/felix/src/test/java/org/apache/aries/rsa/itests/felix/tcp/TestDiscoveryExport.java
+++ b/itests/felix/src/test/java/org/apache/aries/rsa/itests/felix/tcp/TestDiscoveryExport.java
@@ -29,6 +29,7 @@ import org.apache.aries.rsa.examples.echotcp.api.EchoService;
 import org.apache.aries.rsa.itests.felix.RsaTestBase;
 import org.apache.aries.rsa.spi.DistributionProvider;
 import org.apache.aries.rsa.spi.EndpointDescriptionParser;
+import org.apache.aries.rsa.spi.ImportedService;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
 import org.hamcrest.Matchers;
@@ -67,10 +68,11 @@ public class TestDiscoveryExport extends RsaTestBase {
     @Test
     public void testDiscoveryExport() throws Exception {
         EndpointDescription epd = getEndpoint();
-        EchoService service = (EchoService)tcpProvider
-            .importEndpoint(EchoService.class.getClassLoader(),
-                            bundleContext, new Class[]{EchoService.class}, epd);
+        ImportedService importedService = tcpProvider.importEndpoint(EchoService.class.getClassLoader(),
+            bundleContext, new Class[]{EchoService.class}, epd);
+        EchoService service = (EchoService)importedService.getService();
         Assert.assertEquals("test", service.echo("test"));
+        importedService.close();
     }
 
     private EndpointDescription getEndpoint() throws Exception {

--- a/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/FastBinProvider.java
+++ b/provider/fastbin/src/main/java/org/apache/aries/rsa/provider/fastbin/FastBinProvider.java
@@ -35,6 +35,7 @@ import org.apache.aries.rsa.provider.fastbin.tcp.ServerInvokerImpl;
 import org.apache.aries.rsa.provider.fastbin.util.UuidGenerator;
 import org.apache.aries.rsa.spi.DistributionProvider;
 import org.apache.aries.rsa.spi.Endpoint;
+import org.apache.aries.rsa.spi.ImportedService;
 import org.apache.aries.rsa.spi.IntentUnsatisfiedException;
 import org.fusesource.hawtdispatch.Dispatch;
 import org.fusesource.hawtdispatch.DispatchQueue;
@@ -172,15 +173,16 @@ public class FastBinProvider implements DistributionProvider {
     }
 
     @Override
-    public Object importEndpoint(ClassLoader cl,
-                                 BundleContext consumerContext,
-                                 Class[] interfaces,
-                                 EndpointDescription endpoint)
+    public ImportedService importEndpoint(ClassLoader cl,
+                                          BundleContext consumerContext,
+                                          Class[] interfaces,
+                                          EndpointDescription endpoint)
             throws IntentUnsatisfiedException {
 
         String address = (String) endpoint.getProperties().get(FASTBIN_ADDRESS);
         InvocationHandler handler = client.getProxy(address, endpoint.getId(), cl);
-        return Proxy.newProxyInstance(cl, interfaces, handler);
+        Object service = Proxy.newProxyInstance(cl, interfaces, handler);
+        return () -> service;
     }
 
 }

--- a/provider/tcp/src/main/java/org/apache/aries/rsa/provider/tcp/TcpInvocationHandler.java
+++ b/provider/tcp/src/main/java/org/apache/aries/rsa/provider/tcp/TcpInvocationHandler.java
@@ -64,6 +64,16 @@ public class TcpInvocationHandler implements InvocationHandler {
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        // handle Object methods locally so we can use equals, HashMap, etc. normally
+        if (method.getDeclaringClass() == Object.class) {
+            switch (method.getName()) {
+                case "equals": return proxy == args[0];
+                case "hashCode": return System.identityHashCode(proxy);
+                case "toString": return proxy.getClass().getName() + "@"
+                    + Integer.toHexString(System.identityHashCode(proxy));
+            }
+        }
+        // handle remote invocation
         if (Future.class.isAssignableFrom(method.getReturnType()) ||
             CompletionStage.class.isAssignableFrom(method.getReturnType())) {
             return createFutureResult(method, args);

--- a/provider/tcp/src/main/java/org/apache/aries/rsa/provider/tcp/TcpInvocationHandler.java
+++ b/provider/tcp/src/main/java/org/apache/aries/rsa/provider/tcp/TcpInvocationHandler.java
@@ -18,16 +18,18 @@
  */
 package org.apache.aries.rsa.provider.tcp;
 
+import java.io.Closeable;
 import java.io.IOException;
-import java.io.ObjectOutputStream;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.Socket;
-import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
@@ -46,20 +48,127 @@ import org.osgi.util.promise.Promise;
  * which sends the details of the method invocations
  * over a TCP connection, to be executed by the remote service.
  */
-public class TcpInvocationHandler implements InvocationHandler {
+public class TcpInvocationHandler implements InvocationHandler, Closeable {
+
+    private static class Connection {
+        Socket socket;
+        BasicObjectOutputStream out;
+        BasicObjectInputStream in;
+
+        public Connection(Socket socket) throws IOException {
+            this.socket = socket;
+            out = new BasicObjectOutputStream(socket.getOutputStream());
+            in = new BasicObjectInputStream(socket.getInputStream());
+        }
+    }
+
     private String host;
     private int port;
     private String endpointId;
     private ClassLoader cl;
     private int timeoutMillis;
 
-    public TcpInvocationHandler(ClassLoader cl, String host, int port, String endpointId, int timeoutMillis)
-        throws UnknownHostException, IOException {
+    /**
+     * The available (idle) pool of connections.
+     */
+    private final Deque<Connection> pool = new ArrayDeque<>();
+
+    /**
+     * Counts connections currently in use (not in pool).
+     */
+    private int acquired;
+
+    private boolean closed;
+
+    TcpInvocationHandler(ClassLoader cl, String host, int port, String endpointId, int timeoutMillis)
+            throws UnknownHostException, IOException {
         this.cl = cl;
         this.host = host;
         this.port = port;
         this.endpointId = endpointId;
         this.timeoutMillis = timeoutMillis;
+    }
+
+    /**
+     * Acquires a connection - either from the pool if there is
+     * one available, or creates a new one if the pool is empty.
+     * <p>
+     * For each invocation of this method, the {@link #releaseConnection}
+     * method must be called exactly once (even if there was an error!)
+     *
+     * @return a connection
+     * @throws IOException if an error occurs
+     */
+    private Connection acquireConnection() throws IOException {
+        Connection conn;
+        synchronized (pool) {
+            acquired++; // must be first
+            if (closed) {
+                throw new IOException("Connection pool is closed");
+            }
+            conn = pool.pollFirst(); // reuse most recently used connection
+        }
+        // if the pool is empty, create a new connection
+        if (conn == null) {
+            conn = new Connection(openSocket());
+            conn.socket.setSoTimeout(timeoutMillis);
+            conn.socket.setTcpNoDelay(true);
+            conn.in.addClassLoader(cl);
+            conn.out.writeUTF(endpointId); // select endpoint for this connection
+        }
+        return conn;
+    }
+
+    /**
+     * Releases the given connection and returns it to the pool.
+     * <p>
+     * This method must be called exactly once for each invocation
+     * of {@link #acquireConnection()}, regardless of the outcome -
+     * if there was an error, it should be invoked with a null parameter.
+     *
+     * @param conn the released connection, or null if there
+     *             was an error when attempting to acquire one
+     */
+    private void releaseConnection(Connection conn) {
+        synchronized (pool) {
+            acquired--; // must be first
+            if (conn != null) {
+                pool.offerFirst(conn); // add to front of queue so old idle ones can expire
+            }
+            pool.notifyAll();
+        }
+    }
+
+    private void closeConnection(Connection conn) {
+        if (conn != null) {
+            try {
+                conn.socket.close();
+            } catch (IOException ignore) {
+                // we want it closed - nothing else to do
+            }
+        }
+    }
+
+    private void closeConnections() throws IOException {
+        synchronized (pool) {
+            closed = true; // first prevent acquiring new connections
+            while (true) {
+                // close all idle connections
+                for (Iterator<Connection> it = pool.iterator(); it.hasNext(); ) {
+                    closeConnection(it.next());
+                    it.remove();
+                }
+                if (acquired == 0) {
+                    break; // all closed
+                }
+                // wait for additional active connections to be released
+                try {
+                    pool.wait();
+                } catch (InterruptedException ie) {
+                    throw new IOException("interrupted while closing connections", ie);
+                }
+            }
+        }
     }
 
     @Override
@@ -115,33 +224,37 @@ public class TcpInvocationHandler implements InvocationHandler {
     }
 
     private Object handleSyncCall(Method method, Object[] args) throws Throwable {
+        Connection conn = null;
         Throwable error;
         Object result;
-        try (
-                Socket socket = openSocket();
-                ObjectOutputStream out = new BasicObjectOutputStream(socket.getOutputStream())
-            ) {
-            socket.setSoTimeout(timeoutMillis);
-            out.writeUTF(endpointId);
-            out.writeObject(method.getName());
-            out.writeObject(args);
-            out.flush();
 
-            try (BasicObjectInputStream in = new BasicObjectInputStream(socket.getInputStream())) {
-                in.addClassLoader(cl);
-                error = (Throwable) in.readObject();
-                result = readReplaceVersion(in.readObject());
-            }
+        try {
+            conn = acquireConnection();
+
+            // write invocation data
+            conn.out.writeObject(method.getName());
+            conn.out.writeObject(args);
+            conn.out.flush();
+            conn.out.reset();
+            // read result data
+            error = (Throwable)conn.in.readObject();
+            result = readReplaceVersion(conn.in.readObject());
+
             if (error == null)
                 return result;
             else if (error instanceof InvocationTargetException)
                 error = error.getCause(); // exception thrown from remotely invoked method (not our problem)
             else
                 throw error; // exception thrown by provider itself
-        } catch (SocketTimeoutException e) {
-            throw new ServiceException("Timeout calling " + host + ":" + port + " method: " + method.getName(), ServiceException.REMOTE, e);
         } catch (Throwable e) {
-            throw new ServiceException("Error calling " + host + ":" + port + " method: " + method.getName(), ServiceException.REMOTE, e);
+            // this can be an unexpected error from remote (not from the invoked method itself
+            // but somewhere in the provider processing), or a communications error (e.g. timeout) -
+            // in either case we don't know what was written or not, so we must abort the connection
+            closeConnection(conn);
+            conn = null; // don't return it to the pool
+            throw new ServiceException("Error invoking " + method.getName() + " on " + endpointId, ServiceException.REMOTE, e);
+        } finally {
+            releaseConnection(conn);
         }
         throw error;
     }
@@ -168,4 +281,8 @@ public class TcpInvocationHandler implements InvocationHandler {
         }
     }
 
+    @Override
+    public void close() throws IOException {
+        closeConnections();
+    }
 }

--- a/provider/tcp/src/main/java/org/apache/aries/rsa/provider/tcp/TcpInvocationHandler.java
+++ b/provider/tcp/src/main/java/org/apache/aries/rsa/provider/tcp/TcpInvocationHandler.java
@@ -24,6 +24,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.Socket;
+import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -171,6 +172,12 @@ public class TcpInvocationHandler implements InvocationHandler, Closeable {
         }
     }
 
+    private int getPoolSize() {
+        synchronized (pool) {
+            return pool.size() + acquired; // both idle and active
+        }
+    }
+
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         // handle Object methods locally so we can use equals, HashMap, etc. normally
@@ -225,20 +232,33 @@ public class TcpInvocationHandler implements InvocationHandler, Closeable {
 
     private Object handleSyncCall(Method method, Object[] args) throws Throwable {
         Connection conn = null;
-        Throwable error;
-        Object result;
+        Throwable error = null;
+        Object result = null;
 
         try {
-            conn = acquireConnection();
-
-            // write invocation data
-            conn.out.writeObject(method.getName());
-            conn.out.writeObject(args);
-            conn.out.flush();
-            conn.out.reset();
-            // read result data
-            error = (Throwable)conn.in.readObject();
-            result = readReplaceVersion(conn.in.readObject());
+             // try at most all existing connections (which may be stale) plus one new
+            for (int attempts = getPoolSize() + 1; attempts > 0; attempts--) {
+                conn = acquireConnection(); // get or create pool connection
+                try {
+                    // write invocation data
+                    conn.out.writeObject(method.getName());
+                    conn.out.writeObject(args);
+                    conn.out.flush();
+                    conn.out.reset();
+                    // read result data
+                    error = (Throwable) conn.in.readObject();
+                    result = readReplaceVersion(conn.in.readObject());
+                    break; // transaction completed
+                } catch (SocketException se) { // catch only read/write exceptions here - only stale connections
+                    if (attempts == 1) {
+                        throw se; // failed last attempt - propagate the error
+                    }
+                    // the server socket was previously open, but now failed -
+                    // communication error or server socket was closed (e.g. idle timeout)
+                    // so we retry with another connection
+                    releaseConnection(null); // dispose of it before next attempt
+                }
+            }
 
             if (error == null)
                 return result;

--- a/provider/tcp/src/main/java/org/apache/aries/rsa/provider/tcp/TcpProvider.java
+++ b/provider/tcp/src/main/java/org/apache/aries/rsa/provider/tcp/TcpProvider.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import org.apache.aries.rsa.annotations.RSADistributionProvider;
 import org.apache.aries.rsa.spi.DistributionProvider;
 import org.apache.aries.rsa.spi.Endpoint;
+import org.apache.aries.rsa.spi.ImportedService;
 import org.apache.aries.rsa.spi.IntentUnsatisfiedException;
 import org.apache.aries.rsa.util.StringPlus;
 import org.osgi.framework.BundleContext;
@@ -126,17 +127,18 @@ public class TcpProvider implements DistributionProvider {
     }
 
     @Override
-    public Object importEndpoint(ClassLoader cl,
-                                 BundleContext consumerContext,
-                                 Class[] interfaces,
-                                 EndpointDescription endpoint)
+    public ImportedService importEndpoint(ClassLoader cl,
+                                          BundleContext consumerContext,
+                                          Class[] interfaces,
+                                          EndpointDescription endpoint)
         throws IntentUnsatisfiedException {
         try {
             String endpointId = endpoint.getId();
             URI address = new URI(endpointId);
             int timeout = new EndpointPropertiesParser(endpoint).getTimeoutMillis();
             InvocationHandler handler = new TcpInvocationHandler(cl, address.getHost(), address.getPort(), endpointId, timeout);
-            return Proxy.newProxyInstance(cl, interfaces, handler);
+            Object service = Proxy.newProxyInstance(cl, interfaces, handler);
+            return () -> service;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/provider/tcp/src/main/java/org/apache/aries/rsa/provider/tcp/TcpServer.java
+++ b/provider/tcp/src/main/java/org/apache/aries/rsa/provider/tcp/TcpServer.java
@@ -19,6 +19,7 @@
 package org.apache.aries.rsa.provider.tcp;
 
 import java.io.Closeable;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -27,6 +28,7 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.util.Map;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -113,20 +115,25 @@ public class TcpServer implements Closeable, Runnable {
     }
 
     private void handleConnection(Socket socket) {
-        try (Socket sock = socket;
-             BasicObjectInputStream in = new BasicObjectInputStream(socket.getInputStream());
-             ObjectOutputStream out = new BasicObjectOutputStream(socket.getOutputStream())) {
+        try (Socket sock = socket; // socket will be closed when done
+             ObjectOutputStream out = new BasicObjectOutputStream(socket.getOutputStream());
+             BasicObjectInputStream in = new BasicObjectInputStream(socket.getInputStream())) {
+            socket.setTcpNoDelay(true);
             String endpointId = in.readUTF();
             MethodInvoker invoker = invokers.get(endpointId);
             if (invoker == null)
                 throw new IllegalArgumentException("invalid endpoint: " + endpointId);
             in.addClassLoader(invoker.getService().getClass().getClassLoader());
-            handleCall(invoker, in, out);
-        } catch (SocketException se) {
-            return; // e.g. connection closed by client
-        } catch (Exception e) {
-            LOG.warn("Error processing service call", e);
+            while (running) {
+                handleCall(invoker, in, out);
+            }
+        } catch (SocketException | SocketTimeoutException | EOFException se) {
+            LOG.trace("Socket closed", se);
+            return; // e.g. connection closed by client or read timeout due to inactivity
+        } catch (Throwable t) {
+            LOG.warn("Error processing service call", t);
         }
+        // connection is now closed and thread is done
     }
 
     private void handleCall(MethodInvoker invoker, ObjectInputStream in, ObjectOutputStream out) throws Exception {
@@ -141,6 +148,8 @@ public class TcpServer implements Closeable, Runnable {
         }
         out.writeObject(error);
         out.writeObject(result);
+        out.flush();
+        out.reset();
     }
 
     @SuppressWarnings("unchecked")

--- a/provider/tcp/src/test/java/org/apache/aries/rsa/provider/tcp/TcpProviderPrimitiveTest.java
+++ b/provider/tcp/src/test/java/org/apache/aries/rsa/provider/tcp/TcpProviderPrimitiveTest.java
@@ -38,6 +38,7 @@ import org.apache.aries.rsa.provider.tcp.myservice.DTOType;
 import org.apache.aries.rsa.provider.tcp.myservice.PrimitiveService;
 import org.apache.aries.rsa.provider.tcp.myservice.PrimitiveServiceImpl;
 import org.apache.aries.rsa.spi.Endpoint;
+import org.apache.aries.rsa.spi.ImportedService;
 import org.apache.aries.rsa.util.EndpointHelper;
 import org.easymock.EasyMock;
 import org.junit.AfterClass;
@@ -52,6 +53,7 @@ public class TcpProviderPrimitiveTest {
 
     private static PrimitiveService myServiceProxy;
     private static Endpoint ep;
+    private static ImportedService importedService;
 
     @BeforeClass
     public static void createServerAndProxy() {
@@ -66,10 +68,11 @@ public class TcpProviderPrimitiveTest {
         ep = provider.exportService(myService, bc, props, exportedInterfaces);
         assertThat(ep.description().getId(), startsWith("tcp://localhost:"));
         System.out.println(ep.description());
-        myServiceProxy = (PrimitiveService)provider.importEndpoint(PrimitiveService.class.getClassLoader(),
-                                                            bc,
-                                                            exportedInterfaces,
-                                                            ep.description());
+        importedService = provider.importEndpoint(PrimitiveService.class.getClassLoader(),
+            bc,
+            exportedInterfaces,
+            ep.description());
+        myServiceProxy = (PrimitiveService)importedService.getService();
     }
 
     @Test
@@ -164,6 +167,7 @@ public class TcpProviderPrimitiveTest {
 
     @AfterClass
     public static void close() throws IOException {
+        importedService.close();
         ep.close();
     }
 

--- a/provider/tcp/src/test/java/org/apache/aries/rsa/provider/tcp/TcpProviderTest.java
+++ b/provider/tcp/src/test/java/org/apache/aries/rsa/provider/tcp/TcpProviderTest.java
@@ -64,7 +64,7 @@ import org.osgi.util.promise.Success;
 public class TcpProviderTest {
 
     private static final int TIMEOUT = 200;
-    private static final int NUM_CALLS = 100;
+    private static final int NUM_CALLS = 2000; // increase this manually to find the max throughput
     private static final int NUM_THREADS = 10;
 
     private MyService myServiceProxy;
@@ -268,8 +268,10 @@ public class TcpProviderTest {
         }
         executor.shutdown();
         executor.awaitTermination(100, TimeUnit.SECONDS);
-        long tps = NUM_CALLS * 1000 / (System.currentTimeMillis() - start);
-        System.out.println(tps + " tps");
+        long cps = NUM_CALLS * 1000 / (System.currentTimeMillis() - start);
+        long cpst = cps / NUM_THREADS;
+        System.out.println(cpst + " calls per second on each thread");
+        System.out.println(cps + " calls per second total on " + NUM_THREADS + " threads");
     }
 
 }

--- a/provider/tcp/src/test/java/org/apache/aries/rsa/provider/tcp/TcpProviderTest.java
+++ b/provider/tcp/src/test/java/org/apache/aries/rsa/provider/tcp/TcpProviderTest.java
@@ -48,6 +48,7 @@ import org.apache.aries.rsa.provider.tcp.myservice.ExpectedTestException;
 import org.apache.aries.rsa.provider.tcp.myservice.MyService;
 import org.apache.aries.rsa.provider.tcp.myservice.MyServiceImpl;
 import org.apache.aries.rsa.spi.Endpoint;
+import org.apache.aries.rsa.spi.ImportedService;
 import org.apache.aries.rsa.util.EndpointHelper;
 import org.easymock.EasyMock;
 import org.junit.After;
@@ -70,6 +71,8 @@ public class TcpProviderTest {
     private MyService myServiceProxy2;
     private Endpoint ep;
     private Endpoint ep2;
+    private ImportedService importedService;
+    private ImportedService importedService2;
 
     protected static int getFreePort() throws IOException {
         try (ServerSocket socket = new ServerSocket()) {
@@ -96,21 +99,25 @@ public class TcpProviderTest {
         props.put("aries.rsa.id", "service2");
         ep2 = provider.exportService(new MyServiceImpl("service2"), bc, props, exportedInterfaces);
         assertThat(ep.description().getId(), startsWith("tcp://localhost:"));
-        myServiceProxy = (MyService)provider.importEndpoint(
-            MyService.class.getClassLoader(),
-            bc,
-            exportedInterfaces,
-            ep.description());
-        myServiceProxy2 = (MyService)provider.importEndpoint(
-            MyService.class.getClassLoader(),
-            bc,
-            exportedInterfaces,
-            ep2.description());
+        importedService = provider.importEndpoint(
+                MyService.class.getClassLoader(),
+                bc,
+                exportedInterfaces,
+                ep.description());
+        myServiceProxy = (MyService)importedService.getService();
+        importedService2 = provider.importEndpoint(
+                MyService.class.getClassLoader(),
+                bc,
+                exportedInterfaces,
+                ep2.description());
+        myServiceProxy2 = (MyService)importedService2.getService();
     }
 
 
     @After
     public void close() throws IOException {
+        importedService.close();
+        importedService2.close();
         ep.close();
         ep2.close();
     }

--- a/rsa/src/test/java/org/apache/aries/rsa/core/ClientServiceFactoryTest.java
+++ b/rsa/src/test/java/org/apache/aries/rsa/core/ClientServiceFactoryTest.java
@@ -73,7 +73,7 @@ public class ClientServiceFactoryTest {
         EasyMock.expect(handler.importEndpoint(anyObject(ClassLoader.class),
                                                anyObject(BundleContext.class),
                                                isA(Class[].class),
-                                               anyObject(EndpointDescription.class))).andReturn(proxy);
+                                               anyObject(EndpointDescription.class))).andReturn(() -> proxy);
         EasyMock.replay(handler);
         return handler;
     }

--- a/rsa/src/test/java/org/apache/aries/rsa/core/RemoteServiceAdminCoreTest.java
+++ b/rsa/src/test/java/org/apache/aries/rsa/core/RemoteServiceAdminCoreTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.aries.rsa.core.event.EventProducer;
 import org.apache.aries.rsa.spi.DistributionProvider;
 import org.apache.aries.rsa.spi.Endpoint;
+import org.apache.aries.rsa.spi.ImportedService;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.easymock.IMocksControl;
@@ -429,7 +430,7 @@ public class RemoteServiceAdminCoreTest {
         }
 
         @Override
-        public Object importEndpoint(ClassLoader cl, BundleContext consumerContext, Class[] interfaces,
+        public ImportedService importEndpoint(ClassLoader cl, BundleContext consumerContext, Class[] interfaces,
                 EndpointDescription endpoint) {
             return null;
         }

--- a/spi/src/main/java/org/apache/aries/rsa/spi/DistributionProvider.java
+++ b/spi/src/main/java/org/apache/aries/rsa/spi/DistributionProvider.java
@@ -30,7 +30,7 @@ public interface DistributionProvider {
 
     /**
      * Called by RemoteServiceAdmin to export a service.
-     *
+     * <p>
      * The Distribution provider will be called if no config type was set or
      * if it supports the config type.
      *
@@ -46,14 +46,19 @@ public interface DistributionProvider {
                            Class[] exportedInterfaces);
 
     /**
+     * Called by RemoteServiceAdmin to import a service,
+     * i.e. get a proxy that can be used to access the remote service.
+     * <p>
      * @param cl classloader of the consumer bundle
      * @param consumerContext bundle context of the consumer bundle
      * @param interfaces interfaces of the service to proxy
      * @param endpoint description of the remote endpoint
-     * @return service proxy to be given to the requesting bundle
+     * @return an ImportedService that provides the service proxy
+     *         to be given to the requesting bundle, and can be closed
+     *         when the service is no longer used
      */
-    Object importEndpoint(ClassLoader cl,
-                          BundleContext consumerContext,
-                          Class[] interfaces,
-                          EndpointDescription endpoint);
+    ImportedService importEndpoint(ClassLoader cl,
+                                   BundleContext consumerContext,
+                                   Class[] interfaces,
+                                   EndpointDescription endpoint);
 }

--- a/spi/src/main/java/org/apache/aries/rsa/spi/ImportedService.java
+++ b/spi/src/main/java/org/apache/aries/rsa/spi/ImportedService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
@@ -16,7 +16,33 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-@org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("2.0.0")
 package org.apache.aries.rsa.spi;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Wraps an imported service proxy, while allowing it to be properly
+ * closed to release resources, close connections, etc.
+ */
+public interface ImportedService extends Closeable {
+
+    /**
+     * Returns the service proxy to be used by consumer bundles.
+     *
+     * @return the service proxy
+     */
+    Object getService();
+
+    /**
+     * Close the service and release its resources.
+     * <p>
+     * Implementations should override this to release resources
+     * associated with the service, close connections, etc.
+     * when the service is no longer used.
+     *
+     * @throws IOException if an error occurs
+     */
+    default void close() throws IOException {
+    }
+}


### PR DESCRIPTION
Implements ARIES-2121 wtih a simple connection pool. Performance tests (when increasing the number of calls in TcpProviderTest) show an increase in throuput on the order of 100x.

Note that this PR is on top of ARIES-2120, so that PR has to be merged first.